### PR TITLE
Prevent NPE when loading untyped annotations (#141)

### DIFF
--- a/org.bbaw.bts.app.feature/feature.xml
+++ b/org.bbaw.bts.app.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.bbaw.bts.app.feature"
       label="Berlin Text System Core Application"
-      version="3.2.3.qualifier"
+      version="3.2.4.qualifier"
       provider-name="BBAW"
       os="linux,macosx,win32"
       ws="carbon,cocoa,gtk,win32"
@@ -11,6 +11,10 @@
    <description url="http://www.example.com/description">
 Change log
 ==========
+
+Release 3.2.4
+
+	- Fix: NPE in Sign Text Editor caused by untyped annotations (666f02c)
 
 Release 3.2.3
 -------------

--- a/org.bbaw.bts.ui.corpus.egy/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.corpus.egy/META-INF/MANIFEST.MF
@@ -100,4 +100,4 @@ Import-Package: javax.annotation;version="1.0.0",
  org.eclipse.xtext.resource,
  org.elasticsearch.common.recycler,
  org.mihalis.opal.promptSupport
-Bundle-Version: 3.2.3.qualifier
+Bundle-Version: 3.2.4.qualifier

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -730,7 +730,8 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 	 */
 	private void processStylingAnnotations(ElementFigure itemFigure,
 			BTSObject relatingObject) {
-		if (relatingObject instanceof BTSAnnotation 
+		if (relatingObject instanceof BTSAnnotation
+				&& relatingObject.getType() != null
 				&& relatingObject.getType().equals(CorpusUtils.ANNOTATION_RUBRUM_TYPE) 
 				&& itemFigure instanceof WordFigure)
 		{


### PR DESCRIPTION
### Description

Sign text editor fails to load texts with annotations which have no types. (see #141)

#### Related redmine tickets

  * [#11455](https://redmine.bbaw.de/issues/11455)

### Proposed Fix

Prevent operation on null object.